### PR TITLE
Add stacked progressbar in subscriptions

### DIFF
--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -19,6 +19,28 @@
 <div class="progress">
   <div class="progress-bar" role="progressbar" style="width: <%= commited %>%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
 </div>
+<%# STACKED PROGRESS BAR%>
+<div class="progress">
+  <% @users.each do |user| %>
+    <% user_project_amount = user.subscriptions.where(project: @project).sum(&:amount) %>
+    <div class="row">
+      <div class="user-row">
+        <div class="user-box">
+          <% user_percentage = 100 * user_project_amount / @project.amount %>
+          <% user_percentage = user_percentage.round(1) %>
+
+            <div class="progress-bar" role="progressbar" style="<%user_percentage%>" aria-valuenow="15" aria-valuemin="0" aria-valuemax="100"><%= user.name %></div>
+           
+
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+
+<%# STACKED PROGRESS BAR END%>
+
   <%= simple_form_for [@project, @subscription] do |f| %>
       <%= f.input :amount, :label => "Choose the amount (maximum #{number_to_currency(@max_amount)}):" %>
       <%= f.button :submit %>

--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -19,27 +19,22 @@
 <div class="progress">
   <div class="progress-bar" role="progressbar" style="width: <%= commited %>%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
 </div>
-<%# STACKED PROGRESS BAR%>
+
+<%# STACKED PROGRESS BAR START %>
+<p> </p>
 <div class="progress">
-  <% @users.each do |user| %>
+  <% @users.each_with_index do |user, i| %>
     <% user_project_amount = user.subscriptions.where(project: @project).sum(&:amount) %>
-    <div class="row">
-      <div class="user-row">
-        <div class="user-box">
-          <% user_percentage = 100 * user_project_amount / @project.amount %>
-          <% user_percentage = user_percentage.round(1) %>
-
-            <div class="progress-bar" role="progressbar" style="<%user_percentage%>" aria-valuenow="15" aria-valuemin="0" aria-valuemax="100"><%= user.name %></div>
-           
-
-        </div>
-      </div>
-    </div>
+    <% user_percentage = 100 * user_project_amount / @project.amount %>
+    <% user_percentage = user_percentage.round(0) %>
+    <p> </p>
+    <% first_name = user.name.split[0] %>
+    <% colors = %w[secondary primary success warning info dark]%>
+    <div class="progress-bar bg-<%= colors[i] %>" role="progressbar" style="width: <%= user_percentage %>%" aria-valuenow="10" aria-valuemin="0" aria-valuemax="100"><%= first_name %>: <%= user_percentage %>%</div>
   <% end %>
 </div>
 
-
-<%# STACKED PROGRESS BAR END%>
+<%# STACKED PROGRESS BAR END %>
 
   <%= simple_form_for [@project, @subscription] do |f| %>
       <%= f.input :amount, :label => "Choose the amount (maximum #{number_to_currency(@max_amount)}):" %>


### PR DESCRIPTION
We can leave one progress bar, no need for an individual progress bar, as well as the main blue one.

![Subscriptions_colored_bar_chart](https://user-images.githubusercontent.com/62432059/110973971-04cbb680-836f-11eb-8cb3-9acf12eb2717.PNG)
